### PR TITLE
product feeds shouldn't include unavailable items

### DIFF
--- a/lib/spree_google_base/feed_builder.rb
+++ b/lib/spree_google_base/feed_builder.rb
@@ -83,7 +83,9 @@ module SpreeGoogleBase
           ar_scope.find_each() do |product|
             variants = Spree::Variant.find_each()
             variants.each do |variant|
-              if (variant.product_id == product.id && !variant.gtin.nil?) && (product.hide_for_customer == false && variant.hidden == false)
+              if (variant.product_id == product.id && !variant.gtin.nil?) &&
+                 (product.hide_for_customer == false && variant.hidden == false) &&
+                 (variant.try(:stores).empty? || variant.try(:stores).include?(I18n.store))
                 build_product(xml, product, variant)
               end
             end


### PR DESCRIPTION
product feeds are including items that are not available in a given country

this is currently leading to a handful of item issues/disapprovals in google merchant center and seems to be the case primarily with OTC products (i.e. solution, zit stick, invisible shield)

we'll want to rely on the variant's stores value for this logic (this should be reliable as per gina):

<img width="1431" alt="screen shot 2018-09-24 at 3 59 12 pm" src="https://user-images.githubusercontent.com/753440/46087865-32a9ea00-c179-11e8-81e0-1bfafdaae971.png">

which means we'll include the variant in the product feed if either of the below are true:
1. variant's stores value is not set (meaning the product is available in all countries)
2. variant's stores value includes current country

corresponding PR in glossier-v2: https://github.com/glossier/glossier-v2/pull/5156
original CH ticket: https://app.clubhouse.io/glossier-dot-com/story/20837/product-feeds-include-items-not-currently-available-in-country