### PR TITLE
check product's restricted attribute instead of hide_for_customer

### DIFF
--- a/lib/spree_google_base/feed_builder.rb
+++ b/lib/spree_google_base/feed_builder.rb
@@ -84,7 +84,7 @@ module SpreeGoogleBase
             variants = Spree::Variant.find_each()
             variants.each do |variant|
               if (variant.product_id == product.id && !variant.gtin.nil?) &&
-                 (product.hide_for_customer == false && variant.hidden == false) &&
+                 (product.restricted == false && variant.hidden == false) &&
                  (variant.try(:stores).empty? || variant.try(:stores).include?(I18n.store))
                 build_product(xml, product, variant)
               end


### PR DESCRIPTION
Products with `hide_for_customer` set to true should ideally be visible in the product feeds so that Marketing can access them pre-launch in Productsup. It's more accurate for us to be checking if a product is `restricted` (i.e. not visible to user or admin) here instead.

Original CH ticket: https://app.clubhouse.io/glossier-dot-com/story/21965/confirm-that-hide-for-customer-products-are-visible-in-product-feed-but-not-restricted-products